### PR TITLE
fix(sshd): Validation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ access. For sudo verification, this role replaces password verification with
 Yubico OTP. The default deployment config can be tuned with the following
 variables.
 
-`yubikey_sshd_with_pass`
+`yubikey_sshd_and_pass`
 
 Defaults to true, requiring Yubico OTP and password for successful
 authentication. Set to false, to require only Yubico OTP. Results in `sshd`
 requiring  methods implied by flag in addition to those specified in
 `sshd_config` (certificate).
 
-`yubikey_sudo_with_pass`
+`yubikey_sudo_and_pass`
 
 Defaults to false, requiring only Yubico OTP to be granted sudo privileges. Set
 to false, to guard sudo with Yubico OTP and password.

--- a/tasks/configure-sshd.yml
+++ b/tasks/configure-sshd.yml
@@ -67,7 +67,7 @@
     regexp: '^(#.?C|.?C)hallengeResponseAuthentication.*'
     line: 'ChallengeResponseAuthentication yes'
     backup: yes
-    validate: /usr/sbin/sshd -T -f %s
+    validate: /usr/sbin/sshd -T -C user=root -f %s
 
 - name: Update sshd_config - Disable Password Authentication
   lineinfile:
@@ -76,7 +76,7 @@
     regexp: '^#PasswordAuthentication.*'
     line: 'PasswordAuthentication no'
     backup: yes
-    validate: /usr/sbin/sshd -T -f %s
+    validate: /usr/sbin/sshd -T -C user=root -f %s
 
 - name: Update sshd_config - Force yubikey users to use yubikey
   blockinfile:

--- a/tasks/configure-sshd.yml
+++ b/tasks/configure-sshd.yml
@@ -84,5 +84,5 @@
     state: present
     block: "{{ yubikey_sshd_config_addition }}"
     insertafter: EOF
-    validate: /usr/sbin/sshd -T -f %s
+    validate: /usr/sbin/sshd -T -C user=root -f %s
   notify: restart-sshd


### PR DESCRIPTION
The validation command fails when no user is specified. With the following error message:

```
'Match Group' in configuration but 'user' not in connection test specification.
```

This is similar to the issue described here:
https://github.com/dev-sec/ansible-ssh-hardening/issues/188

This was tested on Debian Buster (Stable) with OpenSSH 7.9p1